### PR TITLE
PR-DEV Added Sample GitHubApp (Issue #43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GitHub Apps .NET (Core) - v1.1.0
+# GitHub Apps .NET (Core)
 
 [![nuget](https://img.shields.io/nuget/v/GitHubApps.svg)](https://www.nuget.org/packages/GitHubApps/) 
 ![GitHub release](https://img.shields.io/github/release/olavodias/GitHubApps.svg)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GitHub Apps .NET (Core) - v1.0.1
+# GitHub Apps .NET (Core) - v1.1.0
 
 [![nuget](https://img.shields.io/nuget/v/GitHubApps.svg)](https://www.nuget.org/packages/GitHubApps/) 
 ![GitHub release](https://img.shields.io/github/release/olavodias/GitHubApps.svg)

--- a/src/GitHubApps/AssemblyInfo.cs
+++ b/src/GitHubApps/AssemblyInfo.cs
@@ -26,5 +26,6 @@
 // *****************************************************************************
 using System.Runtime.CompilerServices;
 
-// Allow certain assemblies to see the methods decorated with the "internal" keyword
+// Allow certain assemblies to see the classes or methods decorated with the "internal" keyword
 [assembly: InternalsVisibleTo("GitHubApps.Testing")]
+[assembly: InternalsVisibleTo("GitHubApps.AspNetCore.Mvc.Testing")]

--- a/src/GitHubApps/GitHubApps.csproj
+++ b/src/GitHubApps/GitHubApps.csproj
@@ -9,7 +9,7 @@
 
     <!-- Nuget Package Info -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Authors>Olavo Henrique Dias</Authors>
     <Company>Olavo Henrique Dias</Company>
     <Product>GitHubApps</Product>
@@ -48,9 +48,9 @@
   </PropertyGroup>
   
   <Target Name="DisplayMessages" BeforeTargets="ResolveReferences">
-      <Message Text="Identifier.. = $(_FrameworkIdentifier)"/>
-      <Message Text="Temp........ = $(_TempFrameworkVersion)"/>
-      <Message Text="Version..... = $(_FrameworkVersion)"/>
+      <Message Text="Identifier.. = $(_FrameworkIdentifier)" />
+      <Message Text="Temp........ = $(_TempFrameworkVersion)" />
+      <Message Text="Version..... = $(_FrameworkVersion)" />
   </Target>
 
   <!-- General Nuget Packages -->

--- a/src/GitHubApps/README.MD
+++ b/src/GitHubApps/README.MD
@@ -1,4 +1,4 @@
-﻿# GitHub Apps .NET (Core) - v1.0.1
+﻿# GitHub Apps .NET (Core) - v1.1.0
 
 [![nuget](https://img.shields.io/nuget/v/GitHubApps.svg)](https://www.nuget.org/packages/GitHubApps/) 
 ![GitHub release](https://img.shields.io/github/release/olavodias/GitHubApps.svg)

--- a/src/GitHubApps/README.MD
+++ b/src/GitHubApps/README.MD
@@ -1,4 +1,4 @@
-﻿# GitHub Apps .NET (Core) - v1.1.0
+﻿# GitHub Apps .NET (Core)
 
 [![nuget](https://img.shields.io/nuget/v/GitHubApps.svg)](https://www.nuget.org/packages/GitHubApps/) 
 ![GitHub release](https://img.shields.io/github/release/olavodias/GitHubApps.svg)

--- a/src/GitHubApps/SampleGitHubApp.cs
+++ b/src/GitHubApps/SampleGitHubApp.cs
@@ -1,5 +1,5 @@
 ﻿// *****************************************************************************
-// GitHubApp.cs
+// SampleGitHubApp.cs
 //
 // Author:
 //       Olavo Henrique Dias <olavodias@gmail.com>
@@ -24,36 +24,49 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 // *****************************************************************************
-using System;
+
 using System.Runtime.CompilerServices;
 using GitHubApps.Models;
 using GitHubApps.Models.Events;
 
-namespace GitHubApps.Testing;
+namespace GitHubApps;
 
 /// <summary>
-/// A class to simulate a GitHubApp
+/// Represents a Sample GitHub App to be used for Unit Testing
 /// </summary>
-public sealed class GitHubApp: GitHubAppBase
+/// <remarks>This class is only for unit testing. Whenever the process request method is callsed, it will route the event and populate the property <see cref="LastMethodCalled"/> with the name of the method that was called last.</remarks>
+internal sealed class SampleGitHubApp: GitHubAppBase
 {
-	public GitHubApp()
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SampleGitHubApp"/>
+    /// </summary>
+	public SampleGitHubApp()
 	{
-
 	}
 
-    public string? LastMethodCalled { get; set; }
+    /// <summary>
+    /// The name of the last method that was called
+    /// </summary>
+    public string? LastMethodCalled { get; private set; }
 
+    /// <summary>
+    /// An internal function to be called by all action handlers
+    /// </summary>
+    /// <param name="memberName">The name of the method calling this method</param>
+    /// <returns>A <see cref="EventResult.SuccessEventResult"/></returns>
     private EventResult ProcessMethod([CallerMemberName] string memberName = "")
     {
         LastMethodCalled = memberName.ToLower();
         return EventResult.SuccessEventResult;
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventUnhandled()
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventActionUnhandled()
     {
         return ProcessMethod();
@@ -61,6 +74,7 @@ public sealed class GitHubApp: GitHubAppBase
 
     #region Create Event
 
+    /// <inheritdoc/>
     public override EventResult OnEventCreate(GitHubDelivery<GitHubEventCreate> payload)
     {
         return ProcessMethod();
@@ -70,6 +84,7 @@ public sealed class GitHubApp: GitHubAppBase
 
     #region Delete Event
 
+    /// <inheritdoc/>
     public override EventResult OnEventDelete(GitHubDelivery<GitHubEventDelete> payload)
     {
         return ProcessMethod();
@@ -79,6 +94,7 @@ public sealed class GitHubApp: GitHubAppBase
 
     #region Fork Event
 
+    /// <inheritdoc/>
     public override EventResult OnEventFork(GitHubDelivery<GitHubEventFork> payload)
     {
         return ProcessMethod();
@@ -88,26 +104,31 @@ public sealed class GitHubApp: GitHubAppBase
 
     #region Installation Event
 
+    /// <inheritdoc/>
     public override EventResult OnEventInstallationCreated(GitHubDelivery<GitHubEventInstallation> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventInstallationDeleted(GitHubDelivery<GitHubEventInstallation> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventInstallationNewPermissionsAccepted(GitHubDelivery<GitHubEventInstallation> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventInstallationSuspend(GitHubDelivery<GitHubEventInstallation> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventInstallationUnsuspend(GitHubDelivery<GitHubEventInstallation> payload)
     {
         return ProcessMethod();
@@ -117,16 +138,19 @@ public sealed class GitHubApp: GitHubAppBase
 
     #region Issue Comment Event
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssueCommentCreated(GitHubDelivery<GitHubEventIssueComment> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssueCommentDeleted(GitHubDelivery<GitHubEventIssueComment> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssueCommentEdited(GitHubDelivery<GitHubEventIssueCommentEdited> payload)
     {
         return ProcessMethod();
@@ -136,81 +160,97 @@ public sealed class GitHubApp: GitHubAppBase
 
     #region Issues Event
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesAssigned(GitHubDelivery<GitHubEventIssuesAssigned> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesClosed(GitHubDelivery<GitHubEventIssues> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesDeleted(GitHubDelivery<GitHubEventIssues> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesDemilestoned(GitHubDelivery<GitHubEventIssuesMilestoned> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesEdited(GitHubDelivery<GitHubEventIssuesEdited> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesLabeled(GitHubDelivery<GitHubEventIssuesLabeled> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesLocked(GitHubDelivery<GitHubEventIssues> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesMilestoned(GitHubDelivery<GitHubEventIssuesMilestoned> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesOpened(GitHubDelivery<GitHubEventIssuesChanged> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesPinned(GitHubDelivery<GitHubEventIssues> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesReopened(GitHubDelivery<GitHubEventIssues> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesTransferred(GitHubDelivery<GitHubEventIssuesTransferred> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesUnassigned(GitHubDelivery<GitHubEventIssuesAssigned> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesUnlabeled(GitHubDelivery<GitHubEventIssuesLabeled> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesUnlocked(GitHubDelivery<GitHubEventIssues> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventIssuesUnpinned(GitHubDelivery<GitHubEventIssues> payload)
     {
         return ProcessMethod();
@@ -220,16 +260,19 @@ public sealed class GitHubApp: GitHubAppBase
 
     #region Label Event
 
+    /// <inheritdoc/>
     public override EventResult OnEventLabelCreated(GitHubDelivery<GitHubEventLabel> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventLabelDeleted(GitHubDelivery<GitHubEventLabel> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventLabelEdited(GitHubDelivery<GitHubEventLabelEdited> payload)
     {
         return ProcessMethod();
@@ -239,121 +282,145 @@ public sealed class GitHubApp: GitHubAppBase
 
     #region Pull Request Event
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestAssigned(GitHubDelivery<GitHubEventPullRequestAssigned> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestAutoMergeDisabled(GitHubDelivery<GitHubEventPullRequestReasoned> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestAutoMergeEnabled(GitHubDelivery<GitHubEventPullRequestReasoned> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestClosed(GitHubDelivery<GitHubEventPullRequest> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestConvertedToDraft(GitHubDelivery<GitHubEventPullRequest> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestDemilestoned(GitHubDelivery<GitHubEventPullRequestMilestoned> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestDequeued(GitHubDelivery<GitHubEventPullRequestReasoned> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestEdited(GitHubDelivery<GitHubEventPullRequestEdited> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestEnqueued(GitHubDelivery<GitHubEventPullRequest> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestLabeled(GitHubDelivery<GitHubEventPullRequestLabeled> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestLocked(GitHubDelivery<GitHubEventPullRequest> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestMilestoned(GitHubDelivery<GitHubEventPullRequestMilestoned> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestOpened(GitHubDelivery<GitHubEventPullRequest> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestReadyForReview(GitHubDelivery<GitHubEventPullRequest> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestReopened(GitHubDelivery<GitHubEventPullRequest> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestReviewDismissed(GitHubDelivery<GitHubEventPullRequestReview> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestReviewEdited(GitHubDelivery<GitHubEventPullRequestReviewEdited> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestReviewRequest(GitHubDelivery<GitHubEventPullRequestReviewRequested> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestReviewRequestRemoved(GitHubDelivery<GitHubEventPullRequestReviewRequested> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestReviewSubmitted(GitHubDelivery<GitHubEventPullRequestReview> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestSynchronize(GitHubDelivery<GitHubEventPullRequestSynchronized> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestUnassigned(GitHubDelivery<GitHubEventPullRequestAssigned> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestUnlabeled(GitHubDelivery<GitHubEventPullRequestLabeled> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestUnlocked(GitHubDelivery<GitHubEventPullRequest> payload)
     {
         return ProcessMethod();
@@ -363,16 +430,19 @@ public sealed class GitHubApp: GitHubAppBase
 
     #region Pull Request Review Comment Event
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestReviewCommentCreated(GitHubDelivery<GitHubEventPullRequestReviewComment> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestReviewCommentDeleted(GitHubDelivery<GitHubEventPullRequestReviewComment> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestReviewCommentEdited(GitHubDelivery<GitHubEventPullRequestReviewCommentEdited> payload)
     {
         return ProcessMethod();
@@ -382,11 +452,13 @@ public sealed class GitHubApp: GitHubAppBase
 
     #region Pull Request Review Thread Event
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestReviewThreadResolved(GitHubDelivery<GitHubEventPullRequestReviewThread> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventPullRequestReviewThreadUnresolved(GitHubDelivery<GitHubEventPullRequestReviewThread> payload)
     {
         return ProcessMethod();
@@ -396,6 +468,7 @@ public sealed class GitHubApp: GitHubAppBase
 
     #region Push Event
 
+    /// <inheritdoc/>
     public override EventResult OnEventPush(GitHubDelivery<GitHubEventPush> payload)
     {
         return ProcessMethod();
@@ -405,36 +478,43 @@ public sealed class GitHubApp: GitHubAppBase
 
     #region Release Event
 
+    /// <inheritdoc/>
     public override EventResult OnEventReleaseCreated(GitHubDelivery<GitHubEventRelease> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventReleaseDeleted(GitHubDelivery<GitHubEventRelease> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventReleaseEdited(GitHubDelivery<GitHubEventReleaseEdited> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventReleasePreReleased(GitHubDelivery<GitHubEventRelease> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventReleasePublished(GitHubDelivery<GitHubEventRelease> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventReleaseReleased(GitHubDelivery<GitHubEventRelease> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventReleaseUnpublished(GitHubDelivery<GitHubEventRelease> payload)
     {
         return ProcessMethod();
@@ -444,46 +524,55 @@ public sealed class GitHubApp: GitHubAppBase
 
     #region Repository Event
 
+    /// <inheritdoc/>
     public override EventResult OnEventRepositoryArchived(GitHubDelivery<GitHubEventRepository> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventRepositoryCreated(GitHubDelivery<GitHubEventRepository> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventRepositoryDeleted(GitHubDelivery<GitHubEventRepository> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventRepositoryEdited(GitHubDelivery<GitHubEventRepositoryEdited> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventRepositoryPrivatized(GitHubDelivery<GitHubEventRepository> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventRepositoryPublicized(GitHubDelivery<GitHubEventRepository> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventRepositoryRenamed(GitHubDelivery<GitHubEventRepositoryEdited> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventRepositoryTransferred(GitHubDelivery<GitHubEventRepositoryEdited> payload)
     {
         return ProcessMethod();
     }
 
+    /// <inheritdoc/>
     public override EventResult OnEventRepositoryUnarchived(GitHubDelivery<GitHubEventRepository> payload)
     {
         return ProcessMethod();
@@ -492,5 +581,4 @@ public sealed class GitHubApp: GitHubAppBase
     #endregion Repository Event
 
 }
-
 

--- a/test/GitHubApps.Testing/UnitTestGitHubApp.cs
+++ b/test/GitHubApps.Testing/UnitTestGitHubApp.cs
@@ -43,7 +43,7 @@ public class UnitTestGitHubApp
     [TestMethod]
     public void TestProcessRequest()
     {
-        var gitHubApp = new GitHubApp();
+        var gitHubApp = new SampleGitHubApp();
         Assert.IsTrue(Directory.Exists("Payload"));
         var files = Directory.GetFiles("Payload", "*.json", SearchOption.AllDirectories);
 


### PR DESCRIPTION
Fixed #43 . Create the `SampleGitHubApp` to be used for Unit Testing. This classe is internal, therefore, it cannot be used except by some assemblies, defined on the `AssembllyInfo.cs`.