### PR TITLE
Version v1.2.1

### DIFF
--- a/src/GitHubApps/GitHubAppBase.cs
+++ b/src/GitHubApps/GitHubAppBase.cs
@@ -103,6 +103,10 @@ public abstract partial class GitHubAppBase : IGitHubApp,
                         payloadHeaders.HubSignature256 = headerValue;
                         break;
 
+                    case GitHubHeaders.HEADERS_GITHUB_HOOK_ID:
+                        payloadHeaders.HookID = long.Parse(headerValue);
+                        break;
+
                     case GitHubHeaders.HEADERS_GITHUB_HOOK_INSTALLATION_TARGET_ID:
                         payloadHeaders.HookInstallationTargetID = long.Parse(headerValue);
                         break;

--- a/src/GitHubApps/GitHubApps.csproj
+++ b/src/GitHubApps/GitHubApps.csproj
@@ -9,7 +9,7 @@
 
     <!-- Nuget Package Info -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.2.0</Version>
+    <Version>1.2.1-preview.1</Version>
     <Authors>Olavo Henrique Dias</Authors>
     <Company>Olavo Henrique Dias</Company>
     <Product>GitHubApps</Product>

--- a/src/GitHubApps/GitHubApps.csproj
+++ b/src/GitHubApps/GitHubApps.csproj
@@ -9,7 +9,7 @@
 
     <!-- Nuget Package Info -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.2.1-preview.1</Version>
+    <Version>1.2.1-preview.2</Version>
     <Authors>Olavo Henrique Dias</Authors>
     <Company>Olavo Henrique Dias</Company>
     <Product>GitHubApps</Product>

--- a/src/GitHubApps/GitHubApps.csproj
+++ b/src/GitHubApps/GitHubApps.csproj
@@ -9,7 +9,7 @@
 
     <!-- Nuget Package Info -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.2.1-preview.2</Version>
+    <Version>1.2.1-preview.3</Version>
     <Authors>Olavo Henrique Dias</Authors>
     <Company>Olavo Henrique Dias</Company>
     <Product>GitHubApps</Product>
@@ -77,7 +77,7 @@
     <DefineConstants>HAS_GITHUBAUTH</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition="'$(_FrameworkIdentifier)' == 'net' and '$(_FrameworkVersion)' &gt;= '600'">
-    <PackageReference Include="GitHubAuth" Version="1.0.0" />
+    <PackageReference Include="GitHubAuth" Version="1.0.1" />
   </ItemGroup>
 
   <!-- Configuration Manager Settings -->

--- a/src/GitHubApps/GitHubApps.csproj
+++ b/src/GitHubApps/GitHubApps.csproj
@@ -9,7 +9,7 @@
 
     <!-- Nuget Package Info -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.2.1-preview.3</Version>
+    <Version>1.2.1</Version>
     <Authors>Olavo Henrique Dias</Authors>
     <Company>Olavo Henrique Dias</Company>
     <Product>GitHubApps</Product>
@@ -77,7 +77,7 @@
     <DefineConstants>HAS_GITHUBAUTH</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition="'$(_FrameworkIdentifier)' == 'net' and '$(_FrameworkVersion)' &gt;= '600'">
-    <PackageReference Include="GitHubAuth" Version="1.0.1" />
+    <PackageReference Include="GitHubAuth" Version="1.0.2" />
   </ItemGroup>
 
   <!-- Configuration Manager Settings -->

--- a/src/GitHubApps/Models/Events/GitHubEvent.cs
+++ b/src/GitHubApps/Models/Events/GitHubEvent.cs
@@ -129,6 +129,10 @@ public static class GitHubHeaders
     /// </summary>
     public const string HEADERS_HUB_SIGNATURE_256 = "x-hub-signature-256";
     /// <summary>
+    /// The header key for a GitHub Hook ID
+    /// </summary>
+    public const string HEADERS_GITHUB_HOOK_ID = "x-github-hook-id";
+    /// <summary>
     /// The header signature for a GitHub hook installation target ID
     /// </summary>
     public const string HEADERS_GITHUB_HOOK_INSTALLATION_TARGET_ID = "x-github-hook-installation-target-id";

--- a/src/GitHubApps/Models/GitHubLicense.cs
+++ b/src/GitHubApps/Models/GitHubLicense.cs
@@ -44,7 +44,7 @@ public sealed class GitHubLicense
     /// </summary>
     public string? Name { get; set; }
     /// <include file="documentation_shared.xml" path="Documentation/RepetitiveProperties/RepetitiveProperty[@name=NodeID]"/>
-    public int NodeID { get; set; }
+    public string? NodeID { get; set; }
     /// <summary>
     /// The SPDX ID
     /// </summary>


### PR DESCRIPTION
Fixed #52 (Invalid Type for `GitHubLicense` object).
Fixed #60 (Missing the `X-GitHub-Hook-ID` Header).
Closed #71 (Updated Nuget Package `GitHubAuth` to version `v1.0.2`).